### PR TITLE
Add jekyll-include-cache dep

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :jekyll_plugins do
   gem "jekyll-default-layout"
   gem "jekyll-feed"
   gem "jekyll-gist"
+  gem "jekyll-include-cache"
   gem "jekyll-optional-front-matter"
   gem "jekyll-paginate"
   gem "jekyll-readme-index"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,8 @@ GEM
       jekyll (~> 3.3)
     jekyll-gist (1.5.0)
       octokit (~> 4.2)
+    jekyll-include-cache (0.2.1)
+      jekyll (>= 3.7, < 5.0)
     jekyll-optional-front-matter (0.3.0)
       jekyll (~> 3.0)
     jekyll-paginate (1.1.0)
@@ -97,6 +99,7 @@ DEPENDENCIES
   jekyll-default-layout
   jekyll-feed
   jekyll-gist
+  jekyll-include-cache
   jekyll-optional-front-matter
   jekyll-paginate
   jekyll-readme-index
@@ -109,4 +112,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   1.16.1
+   1.17.2


### PR DESCRIPTION
After running the below:
```
bundle install
bundle exec jekyll serve
```
Got this error:
```
Dependency Error: Yikes! It looks like you don't have jekyll-include-cache or one of its dependencies installed. In order to use Jekyll as currently configured, you'll need to install this gem. The full error message from Ruby is: 'cannot load such file -- jekyll-include-cache' If you run into trouble, you can find helpful resources at https://jekyllrb.com/help/!
```

Adding `gem "jekyll-include-cache"` to the `:jekyll_plugins` group resolved the error. I'll admit I'm not particularly familiar with ruby gems, but figured I'd put up this PR in case it is the right way to fix this to save you time if it is the correct fix.